### PR TITLE
P0: Fix redirect sludge and protect service pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,43 +10,55 @@ const nextConfig = {
         destination: 'https://www.themadhatterchimneysweep.com/:path*',
         permanent: true,
       },
-      // Service pages (trailing slash -> no trailing slash)
-      { source: '/services/dryer-vent-cleaning/', destination: '/', permanent: true },
-      { source: '/services/chimney-sweep/', destination: '/services/chimney-sweeping', permanent: true },
-      { source: '/services/chimney-inspection/', destination: '/services/chimney-inspection', permanent: true },
+
+      // High-value legacy WordPress URLs from Search Console.
+      // Keep these as explicit redirects so we do not damage real /services/* pages.
+      { source: '/services/dryer-vent-cleaning/', destination: '/services', permanent: true },
+      { source: '/services/dryer-vent-cleaning', destination: '/services', permanent: true },
+      { source: '/services/chimney-sweep/', destination: '/services/chimney-inspection-sweeping', permanent: true },
+      { source: '/services/chimney-sweep', destination: '/services/chimney-inspection-sweeping', permanent: true },
+      { source: '/services/chimney-inspection/', destination: '/services/chimney-inspection-sweeping', permanent: true },
+      { source: '/services/chimney-inspection', destination: '/services/chimney-inspection-sweeping', permanent: true },
       { source: '/services/chimney-repair/', destination: '/services/chimney-repairs', permanent: true },
+      { source: '/services/chimney-repair', destination: '/services/chimney-repairs', permanent: true },
       { source: '/services/chimney-cap-installation/', destination: '/services/chimney-caps', permanent: true },
+      { source: '/services/chimney-cap-installation', destination: '/services/chimney-caps', permanent: true },
       { source: '/services/chimney-flashing/', destination: '/services/leak-repair', permanent: true },
+      { source: '/services/chimney-flashing', destination: '/services/leak-repair', permanent: true },
       { source: '/services/chimney-liner/', destination: '/services/chimney-relining', permanent: true },
+      { source: '/services/chimney-liner', destination: '/services/chimney-relining', permanent: true },
       { source: '/services/masonry-repair/', destination: '/services/rebuilds-restorations', permanent: true },
+      { source: '/services/masonry-repair', destination: '/services/rebuilds-restorations', permanent: true },
       { source: '/services/wood-stove-cleaning/', destination: '/services', permanent: true },
+      { source: '/services/wood-stove-cleaning', destination: '/services', permanent: true },
       { source: '/services/', destination: '/services', permanent: true },
 
       // Legacy blog/content pages (with AND without trailing slash)
       { source: '/blog/', destination: '/blog', permanent: true },
-      { source: '/mad-hatter-chimney-sweep-seattle/', destination: '/about', permanent: true },
-      { source: '/mad-hatter-chimney-sweep-seattle', destination: '/about', permanent: true },
-      { source: '/fireplace-chimney-cleaning-seattle/', destination: '/chimney-cleaning', permanent: true },
-      { source: '/fireplace-chimney-cleaning-seattle', destination: '/chimney-cleaning', permanent: true },
-      { source: '/get-cleaner-chimney-fireplace-today/', destination: '/chimney-cleaning', permanent: true },
-      { source: '/get-cleaner-chimney-fireplace-today', destination: '/chimney-cleaning', permanent: true },
+      { source: '/mad-hatter-chimney-sweep-seattle/', destination: '/chimney-sweep-seattle', permanent: true },
+      { source: '/mad-hatter-chimney-sweep-seattle', destination: '/chimney-sweep-seattle', permanent: true },
+      { source: '/fireplace-chimney-cleaning-seattle/', destination: '/chimney-cleaning-seattle', permanent: true },
+      { source: '/fireplace-chimney-cleaning-seattle', destination: '/chimney-cleaning-seattle', permanent: true },
+      { source: '/get-cleaner-chimney-fireplace-today/', destination: '/chimney-cleaning-seattle', permanent: true },
+      { source: '/get-cleaner-chimney-fireplace-today', destination: '/chimney-cleaning-seattle', permanent: true },
       { source: '/about-mad-hatter-chimney-sweep/', destination: '/about', permanent: true },
       { source: '/about-mad-hatter-chimney-sweep', destination: '/about', permanent: true },
-      { source: '/contact/', destination: '/', permanent: true },
-      { source: '/contact', destination: '/', permanent: true },
-      { source: '/contact-us/', destination: '/', permanent: true },
-      { source: '/contact-us', destination: '/', permanent: true },
+      { source: '/contact/', destination: '/#contact', permanent: true },
+      { source: '/contact', destination: '/#contact', permanent: true },
+      { source: '/contact-us/', destination: '/#contact', permanent: true },
+      { source: '/contact-us', destination: '/#contact', permanent: true },
       { source: '/privacy-policy/', destination: '/privacy-policy', permanent: true },
       { source: '/about/', destination: '/about', permanent: true },
 
       // Legacy WordPress category/author archives (tag, feed, and wp-* are handled in middleware)
       { source: '/category/chimney-services/', destination: '/services', permanent: true },
+      { source: '/category/chimney-services', destination: '/services', permanent: true },
       { source: '/author/drmoh/', destination: '/about', permanent: true },
       { source: '/author/drmoh', destination: '/about', permanent: true },
 
-      // Catch-all legacy WordPress author archives
+      // Catch-all legacy WordPress author archives only.
+      // DO NOT add a /services/:slug* catch-all here; it redirects valid service pages away.
       { source: '/author/:slug*', destination: '/about', permanent: true },
-      { source: '/services/:slug*', destination: '/', permanent: true },
     ]
   },
   images: {


### PR DESCRIPTION
Removes dangerous /services/* catch-all redirect that could send valid service URLs to homepage. Tightens legacy WP redirects and fixes contact routing to anchor.

This is the actual P0 routing fix for GSC redirect errors.

## Summary by Sourcery

Tighten and correct legacy redirect rules to preserve valid service URLs and route key WordPress URLs and contact pages to the appropriate modern destinations.

Bug Fixes:
- Correct legacy /services/* redirects so old service URLs map to the appropriate services pages instead of the homepage.
- Fix legacy contact URLs so they redirect directly to the on-page contact section instead of the homepage.
- Ensure legacy blog and SEO-targeted URLs redirect to the updated, location-specific chimney service pages rather than generic destinations.
- Restrict catch-all redirects to WordPress author archives only, avoiding unintended redirects of valid service routes.

Enhancements:
- Add explicit trailing and non-trailing slash variants for important legacy service URLs and a chimney-services category URL to improve redirect coverage and consistency.