### PR TITLE
[codex] fix post-merge audit splinters

### DIFF
--- a/app/chimney-sweep-bothell/page.tsx
+++ b/app/chimney-sweep-bothell/page.tsx
@@ -32,7 +32,7 @@ export default function ChimneySweepBothellPage() {
                 <Link href="/contact">Schedule Service</Link>
               </Button>
               <Button size="lg" variant="outline" asChild className="text-base">
-                <Link href="/pricing">View Pricing</Link>
+                <Link href="/contact">View Pricing</Link>
               </Button>
             </div>
             <p className="mt-6 text-sm text-muted-foreground">

--- a/app/locations/[slug]/page.tsx
+++ b/app/locations/[slug]/page.tsx
@@ -261,6 +261,8 @@ const canonicalLocationPaths = canonicalLocationSlugs.reduce<Record<string, stri
   return acc
 }, {})
 
+canonicalLocationPaths.issaquah = "/locations/issaquah"
+
 export async function generateStaticParams() {
   return Object.keys(locations).map((slug) => ({
     slug: slug,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -73,7 +73,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     '/chimney-sweep-renton',
     '/chimney-sweep-kent',
     '/chimney-sweep-sammamish',
-    '/chimney-sweep-issaquah',
     '/chimney-sweep-bothell',
     '/chimney-sweep-woodinville',
     '/chimney-sweep-shoreline',

--- a/next.config.js
+++ b/next.config.js
@@ -36,6 +36,10 @@ const nextConfig = {
       { source: '/get-cleaner-chimney-fireplace-today', destination: '/chimney-cleaning-seattle', permanent: true },
       { source: '/mad-hatter-chimney-sweep-seattle/', destination: '/chimney-sweep-seattle', permanent: true },
       { source: '/mad-hatter-chimney-sweep-seattle', destination: '/chimney-sweep-seattle', permanent: true },
+      { source: '/chimney-sweep-issaquah/', destination: '/locations/issaquah', permanent: true },
+      { source: '/chimney-sweep-issaquah', destination: '/locations/issaquah', permanent: true },
+      { source: '/pricing/', destination: '/contact', permanent: true },
+      { source: '/pricing', destination: '/contact', permanent: true },
 
       // Keep one canonical service URL family: indexed flat pages.
       { source: '/services/chimney-inspection-sweeping/', destination: '/chimney-inspection', permanent: true },


### PR DESCRIPTION
## Summary

Tiny post-merge audit cleanup after PR #40. This only addresses the two confirmed 404 paths and the broken Issaquah canonical/sitemap entry. No city content, service hierarchy, or broader URL architecture changes.

## Changes

- Add permanent redirects:
  - `/chimney-sweep-issaquah` and `/chimney-sweep-issaquah/` -> `/locations/issaquah`
  - `/pricing` and `/pricing/` -> `/contact`
- Remove `/chimney-sweep-issaquah` from `sitemap.xml` generation.
- Fix `/locations/issaquah` canonical so it points to `/locations/issaquah` instead of missing `/chimney-sweep-issaquah`.
- Change the one internal Bothell pricing link from `/pricing` to `/contact`.

## Validation

- Ran `NODE_OPTIONS=--use-system-ca npm run build` successfully.
- Local production probes:
  - `/chimney-sweep-issaquah` -> `/locations/issaquah`
  - `/chimney-sweep-issaquah/` -> `/locations/issaquah`
  - `/pricing` -> `/contact`
  - `/pricing/` -> `/contact`
  - `/locations/issaquah` -> `200`
  - `/sitemap.xml` -> `200`
- Verified sitemap contains `/locations/issaquah` and does not contain `/chimney-sweep-issaquah`.
- Verified `/locations/issaquah` renders canonical `https://www.themadhatterchimneysweep.com/locations/issaquah`.

## Production probes after merge

```bash
curl --ssl-no-revoke -IL https://www.themadhatterchimneysweep.com/chimney-sweep-issaquah
curl --ssl-no-revoke -IL https://www.themadhatterchimneysweep.com/chimney-sweep-issaquah/
curl --ssl-no-revoke -IL https://www.themadhatterchimneysweep.com/pricing
curl --ssl-no-revoke -IL https://www.themadhatterchimneysweep.com/pricing/
curl --ssl-no-revoke -s https://www.themadhatterchimneysweep.com/sitemap.xml | findstr chimney-sweep-issaquah
curl --ssl-no-revoke -s https://www.themadhatterchimneysweep.com/locations/issaquah | findstr canonical
```

## Summary by Sourcery

Adjust Issaquah and pricing URLs to fix broken links and ensure correct canonical and sitemap entries.

Bug Fixes:
- Add permanent redirects from deprecated Issaquah and pricing URLs to their current destinations.
- Correct the canonical URL mapping for the Issaquah location page.
- Remove the deprecated Issaquah chimney sweep path from sitemap generation and update an internal pricing link to point to the contact page.